### PR TITLE
Parse urls

### DIFF
--- a/api.coffee
+++ b/api.coffee
@@ -75,6 +75,8 @@ module.exports = (API_TOKEN, HOOK_URL)->
         "@#{data['users.simple'][userId]}"
       .replace /<(\S*)>/g, (match, link)->
         link
+      .replace /http(s)?:\/\/([^\s]*)\|([^\s]*)/g, (match, protocol, href1, href2) ->
+        return ("http" + (protocol||"") + "://" + href1) if href1 == href2
       .replace /&amp;/g, "&"
       .replace /&lt;/g, "<"
       .replace /&gt;/g, ">"

--- a/test/incoming.coffee
+++ b/test/incoming.coffee
@@ -1,0 +1,8 @@
+slack = require '../api.coffee'
+assert = require 'assert'
+
+api = slack(process.env.API_TOKEN, 'http://httpbin.org/post')
+
+it 'should parse message of type http://x.y.z|x.y.z', ()->
+  res = api.parseMessage('https://google.com|google.com')
+  assert res == 'https://google.com'


### PR DESCRIPTION
Slack sends urls of the type "google.com" as "http://google.com|google.com".
This PR parses "http://google.com|google.com" to "http://google.com".
